### PR TITLE
Update Steam Avatar CDN URL + Player spawn hook

### DIFF
--- a/addons/DiscordRelay/lua/autorun/server/sv_discord_relay.lua
+++ b/addons/DiscordRelay/lua/autorun/server/sv_discord_relay.lua
@@ -53,7 +53,7 @@ hook.Add("PlayerAuthed", "DiscordFetchAvatar", function(client, steamid)
 end)
 
 hook.Add("PlayerSpawn", "DiscordPlayerSpawn", function(client)
-    fetchedavatars[client:SteamID64()] = nil
+    fetchAvatarURL(util.SteamIDTo64(steamid))
 end)
 
 hook.Add("PlayerDisconnected", "DiscordClearAvatar", function(client)

--- a/addons/DiscordRelay/lua/autorun/server/sv_discord_relay.lua
+++ b/addons/DiscordRelay/lua/autorun/server/sv_discord_relay.lua
@@ -52,7 +52,6 @@ hook.Add("PlayerAuthed", "DiscordFetchAvatar", function(client, steamid)
     fetchAvatarURL(util.SteamIDTo64(steamid))
 end)
 
-// Played Spawned
 hook.Add("PlayerSpawn", "DiscordPlayerSpawn", function(client)
     fetchAvatarURL(util.SteamIDTo64(steamid))
 end)

--- a/addons/DiscordRelay/lua/autorun/server/sv_discord_relay.lua
+++ b/addons/DiscordRelay/lua/autorun/server/sv_discord_relay.lua
@@ -53,7 +53,7 @@ hook.Add("PlayerAuthed", "DiscordFetchAvatar", function(client, steamid)
 end)
 
 hook.Add("PlayerSpawn", "DiscordPlayerSpawn", function(client)
-    fetchAvatarURL(util.SteamIDTo64(steamid))
+    fetchedavatars[client:SteamID64()] = nil
 end)
 
 hook.Add("PlayerDisconnected", "DiscordClearAvatar", function(client)

--- a/addons/DiscordRelay/lua/autorun/server/sv_discord_relay.lua
+++ b/addons/DiscordRelay/lua/autorun/server/sv_discord_relay.lua
@@ -42,7 +42,7 @@ local function fetchAvatarURL(steamID64)
     if fetchedavatars[steamID64] then return fetchedavatars[steamID64] end
 
     http.Fetch("http://steamcommunity.com/profiles/" .. steamID64 .. "/?xml=1", function(body)
-        local link = body:match("https://cdn.akamai.steamstatic.com/steamcommunity/public/images/avatars/.-jpg")
+        local link = body:match("https://avatars.cloudflare.steamstatic.com/.-jpg")
         if not link then return end
         fetchedavatars[steamID64] = link:Replace(".jpg", "_full.jpg")
     end)

--- a/addons/DiscordRelay/lua/autorun/server/sv_discord_relay.lua
+++ b/addons/DiscordRelay/lua/autorun/server/sv_discord_relay.lua
@@ -53,7 +53,7 @@ hook.Add("PlayerAuthed", "DiscordFetchAvatar", function(client, steamid)
 end)
 
 hook.Add("PlayerSpawn", "DiscordPlayerSpawn", function(client)
-    fetchAvatarURL(util.SteamIDTo64(steamid))
+    fetchedavatars[client:SteamID64()]
 end)
 
 hook.Add("PlayerDisconnected", "DiscordClearAvatar", function(client)

--- a/addons/DiscordRelay/lua/autorun/server/sv_discord_relay.lua
+++ b/addons/DiscordRelay/lua/autorun/server/sv_discord_relay.lua
@@ -52,6 +52,11 @@ hook.Add("PlayerAuthed", "DiscordFetchAvatar", function(client, steamid)
     fetchAvatarURL(util.SteamIDTo64(steamid))
 end)
 
+// Played Spawned
+hook.Add("PlayerSpawn", "DiscordPlayerSpawn", function(client)
+    fetchAvatarURL(util.SteamIDTo64(steamid))
+end)
+
 hook.Add("PlayerDisconnected", "DiscordClearAvatar", function(client)
     fetchedavatars[client:SteamID64()] = nil
 end)

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -19,7 +19,11 @@ wss.on("connection", async (socket: WebSocket, req: IncomingMessage): Promise<vo
       const message: Response = JSON.parse(data.toString());
 
       webhook.setUsername(message.user);
-      webhook.setAvatar(message.avatar ? message.avatar : "");
+      if (message.avatar) {
+        webhook.setAvatar(message.avatar ? message.avatar : "");
+      } else {
+        console.log("Failed fetching avatar");
+      }
       await webhook.send(message.text);
     });
   } else {

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -6,7 +6,7 @@ import { IncomingMessage } from "http";
 
 type Response = {
   user: string,
-  avatar?: `https://cdn.akamai.steamstatic.com/steamcommunity/public/images/avatars/${number}_full.jpg`,
+  avatar?: `https://avatars.cloudflare.steamstatic.com/${number}_full.jpg`,
   text: string
 }
 

--- a/web/src/app.ts
+++ b/web/src/app.ts
@@ -22,7 +22,8 @@ wss.on("connection", async (socket: WebSocket, req: IncomingMessage): Promise<vo
       if (message.avatar) {
         webhook.setAvatar(message.avatar ? message.avatar : "");
       } else {
-        console.log("Failed fetching avatar");
+        console.log("Failed fetching avatar, setting default avatar.");
+        webhook.setAvatar("https://cdn.discordapp.com/embed/avatars/0.png");
       }
       await webhook.send(message.text);
     });


### PR DESCRIPTION
- It seems like the #3 avatar issue is correct as double-checked. Here's an example of my avatar: https://avatars.cloudflare.steamstatic.com/23de107cbb6c38ccace7e8bda100fa872044918b_full.jpg
- Added an if statement that should trigger if the CDN URL dies or changes, which will at least give a bit more input than the program outright crashing.
- Add PlayerSpawn hook as requested in #4